### PR TITLE
Add buffer space to interrupt signals channel

### DIFF
--- a/profilesvc/cmd/profilesvc/main.go
+++ b/profilesvc/cmd/profilesvc/main.go
@@ -36,7 +36,7 @@ func main() {
 		h = profilesvc.MakeHTTPHandler(s, log.With(logger, "component", "HTTP"))
 	}
 
-	errs := make(chan error)
+	errs := make(chan error, 1)
 	go func() {
 		c := make(chan os.Signal)
 		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Minor improvement regarding signal.Nofity function's [description](https://github.com/golang/go/blob/2622235a99800d1d7add47c5c138f5efbe51361c/src/os/signal/signal.go#L109): 

"Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate. For a channel used for notification of just one signal value a buffer of size 1 is sufficient."
